### PR TITLE
Updated the terminal foreground color 

### DIFF
--- a/themes/zedspace.json
+++ b/themes/zedspace.json
@@ -66,7 +66,7 @@
         "editor.document_highlight.read_background": "#00000000",
         "editor.document_highlight.write_background": "#00000000",
         "terminal.background": "#101010",
-        "terminal.foreground": "#101010",
+        "terminal.foreground": "#DEDEE3",
         "terminal.bright_foreground": "#101010",
         "terminal.dim_foreground": "#101010",
         "terminal.ansi.black": "#24232A",
@@ -374,3 +374,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
Hi, 
I installed the theme today, and noticed that the foreground color for the terminal is the same as the background, leading to the text in the terminal to not be visible. I updated the color  to be the same as the default editor foreground.

Beautiful theme btw!

Cheers.